### PR TITLE
DTSPO-15347 add azurerm_servicebus_subscription_rule resource

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  TF_VERSION: 0.14.3
+  TF_VERSION: 1.6.3
 
 jobs:
   terraform:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *tfstate*
 *.swp
 .idea/*
+.terraform.lock.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.77.0
+    hooks:
+      - id: terraform_fmt
+        verbose: true
+      - id: terraform_docs
+        args:
+          - --args=--config=.terraform-docs.yml
+          - --hook-config=--path-to-file=README.md
+          

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,13 @@
+# https://terraform-docs.io/user-guide/configuration/
+
+settings:
+  hide-empty: true
+
+formatter: "md"
+
+output:
+  file: README.md
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module "servicebus-subscription" {
 
 ## azurerm_servicebus_subscription_rule
 
-The following example shows how to add azurerm_servicebus_subscription_rule:
+The following example shows how to add a servicebus subscription rule:
 
 ```terraform
 locals {

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module "servicebus-subscription" {
 
 ## azurerm_servicebus_subscription_rule
 
-The following example shows how to give read access to a user assigned managed identity for the subscription:
+The following example shows how to add azurerm_servicebus_subscription_rule:
 
 ```terraform
 locals {

--- a/README.md
+++ b/README.md
@@ -19,26 +19,38 @@ module "servicebus-subscription" {
 }
 ```
 
-## Variables
+## azurerm_servicebus_subscription_rule
 
-### Configuration
+The following example shows how to give read access to a user assigned managed identity for the subscription:
 
-The following parameters are required by this module
+```terraform
+locals {
+  sql_filters = {
+    "hmc-servicebus-aat-subscription-rule-civil" : {
+      sql_filter = "hmctsServiceId IN ('AAA7','AAA6')"
+    }
+  }
 
-- `name` the name of the ServiceBus namespace.
-- `resource_group_name` the name of the resource group in which to create the ServiceBus namespace.
-- `namespace_name` the name of the service bus namespace in which the subscription must be created.
-- `topic_name` the name of the service bus topic in which the subscription must be created.
-
-The following parameters are optional
-
-- `max_delivery_count` the maximum number of deliveries. Default is 10.
-- `lock_duration` the lock duration for the subscription as an ISO 8601 duration. Default is PT1M.
-- `forward_to` the name of a Queue or Topic to automatically forward messages to.
-- `forward_dead_lettered_messages_to` the name of a Queue or Topic to automatically forward Dead Letter messages to.
+  correlation_filters = {
+    correlation_filter1 : {
+      properties = {
+        hmctsProperty = "any"
+      }
+    }
+  }
+}
+module "servicebus-subscription" {
+  source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
+  name                = "hmc-to-civil-subscription"
+  namespace_name      = "hmc-servicebus"
+  topic_name          = "hmc-to-cft"
+  resource_group_name = "hmc-shared"
+  sql_filters         = local.sql_filters
+  correlation_filters = local.correlation_filters
+}
+```
 
 ## Managed Identity Role Assignment
-
 The following example shows how to give read access to a user assigned managed identity for the subscription:
 
 ```terraform
@@ -53,3 +65,51 @@ module "servicebus-subscription" {
   managed_identity_object_id = "your-mi-object-id"
 }
 ```
+
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.79.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_role_assignment.mi_role_assignment_receiver](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_servicebus_subscription.servicebus_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_subscription) | resource |
+| [azurerm_servicebus_subscription_rule.correlation_filter_rules](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_subscription_rule) | resource |
+| [azurerm_servicebus_subscription_rule.sql_filter_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_subscription_rule) | resource |
+| [azurerm_servicebus_topic.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/servicebus_topic) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_correlation_filters"></a> [correlation\_filters](#input\_correlation\_filters) | A map of correlation filters to create rules for which messages will be forwarded from the topic to the subscription. If left undefined or empty all messages will be forwarded. Defaults to {}. | <pre>map(object({<br>    content_type        = optional(string)<br>    correlation_id      = optional(string)<br>    label               = optional(string)<br>    message_id          = optional(string)<br>    reply_to            = optional(string)<br>    reply_to_session_id = optional(string)<br>    session_id          = optional(string)<br>    to                  = optional(string)<br>    properties          = optional(map(string))<br>  }))</pre> | `{}` | no |
+| <a name="input_forward_dead_lettered_messages_to"></a> [forward\_dead\_lettered\_messages\_to](#input\_forward\_dead\_lettered\_messages\_to) | Topic or Queue to forwards dead lettered messages to | `string` | `""` | no |
+| <a name="input_forward_to"></a> [forward\_to](#input\_forward\_to) | Topic or Queue to forwards received messages to | `string` | `""` | no |
+| <a name="input_lock_duration"></a> [lock\_duration](#input\_lock\_duration) | Message lock duration (ISO-8601) | `string` | `"PT1M"` | no |
+| <a name="input_managed_identity_object_id"></a> [managed\_identity\_object\_id](#input\_managed\_identity\_object\_id) | the object id of the managed identity - can be retrieved with az identity show --name <identity-name>-sandbox-mi -g managed-identities-<env>-rg --subscription DCD-CFTAPPS-<env> --query principalId -o tsv | `any` | `null` | no |
+| <a name="input_max_delivery_count"></a> [max\_delivery\_count](#input\_max\_delivery\_count) | Maximum number of attempts to deliver a message before it's sent to dead letter queue | `number` | `10` | no |
+| <a name="input_name"></a> [name](#input\_name) | Azure Service Bus subscription name | `string` | n/a | yes |
+| <a name="input_namespace_name"></a> [namespace\_name](#input\_namespace\_name) | Azure Service Bus namespace | `string` | n/a | yes |
+| <a name="input_requires_session"></a> [requires\_session](#input\_requires\_session) | A value that indicates whether the queue supports the concept of sessions | `bool` | `false` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group in which the Service Bus subscription should exist | `string` | n/a | yes |
+| <a name="input_sql_filters"></a> [sql\_filters](#input\_sql\_filters) | A map of sql filters | <pre>map(object({<br>    sql_filter = optional(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | Azure Service Bus topic name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -19,3 +19,33 @@ resource "azurerm_servicebus_subscription" "servicebus_subscription" {
   default_message_ttl                  = "P10675199DT2H48M5.4775807S"
   auto_delete_on_idle                  = "P10675199DT2H48M5.4775807S"
 }
+
+resource "azurerm_servicebus_subscription_rule" "sql_filter_rule" {
+  for_each        = var.sql_filters
+  name            = each.key
+  subscription_id = azurerm_servicebus_subscription.servicebus_subscription.id
+  filter_type     = "SqlFilter"
+  sql_filter      = lookup(each.value, "sql_filter", null)
+
+}
+
+resource "azurerm_servicebus_subscription_rule" "correlation_filter_rules" {
+  for_each = var.correlation_filters
+
+  name        = each.key
+  filter_type = "CorrelationFilter"
+
+  subscription_id = azurerm_servicebus_subscription.servicebus_subscription.id
+
+  correlation_filter {
+    content_type        = lookup(each.value, "content_type", null)
+    correlation_id      = lookup(each.value, "correlation_id", null)
+    label               = lookup(each.value, "label", null)
+    message_id          = lookup(each.value, "message_id", null)
+    reply_to            = lookup(each.value, "reply_to", null)
+    reply_to_session_id = lookup(each.value, "reply_to_session_id", null)
+    session_id          = lookup(each.value, "session_id", null)
+    to                  = lookup(each.value, "to", null)
+    properties          = lookup(each.value, "properties", null)
+  }
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     azurerm = {
-      source                = "hashicorp/azurerm"
-      version               = ">= 3.0.0"
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "managed_identity_object_id" {
 
 variable "sql_filters" {
   type = map(object({
-    content_type = optional(string)
+    sql_filter = optional(string)
   }))
   description = "A map of sql filters"
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,36 @@ variable "managed_identity_object_id" {
   default     = null
   description = "the object id of the managed identity - can be retrieved with az identity show --name <identity-name>-sandbox-mi -g managed-identities-<env>-rg --subscription DCD-CFTAPPS-<env> --query principalId -o tsv"
 }
+
+variable "sql_filters" {
+  type = map(object({
+    content_type = optional(string)
+  }))
+  description = "A map of sql filters"
+  default     = {}
+}
+
+variable "correlation_filters" {
+  type = map(object({
+    content_type        = optional(string)
+    correlation_id      = optional(string)
+    label               = optional(string)
+    message_id          = optional(string)
+    reply_to            = optional(string)
+    reply_to_session_id = optional(string)
+    session_id          = optional(string)
+    to                  = optional(string)
+    properties          = optional(map(string))
+  }))
+  description = "A map of correlation filters to create rules for which messages will be forwarded from the topic to the subscription. If left undefined or empty all messages will be forwarded. Defaults to {}."
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for name, filter in var.correlation_filters : anytrue([
+        for key, value in filter : value != null
+      ])
+    ])
+    error_message = "At least one of \"content_type\", \"correlation_id\", \"label\", \"message_id\", \"reply_to\", \"reply_to_session_id\", \"session_id\", \"to\" or \"properties\" must be set on every correlation_filter block."
+  }
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15347

### Change description ###
added azurerm_servicebus_subscription_rule resource to this module so that the consuming repo can deploy that resource.
Tested it on civil-service repo - 
Example PR - https://github.com/hmcts/civil-service/pull/3533/files
Pipeline - https://build.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcivil-service/detail/PR-3533/4/pipeline/202


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

