### PR TITLE
Update to batched_operations_enabled because of provider changes

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,35 +5,36 @@ on:
     branches:
       - master
 
-env:
-  TF_VERSION: 1.6.3
-
 jobs:
   terraform:
     name: 'terraform'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: hmcts/cnp-azuredevops-libraries
+          path: cnp-azuredevops-libraries
+
+      - name: Setup Script
+        run: |
+          chmod +x cnp-azuredevops-libraries/scripts/tfenv-install-terraform.sh
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Setup providers configuration
+        run: ./cnp-azuredevops-libraries/scripts/tfenv-install-terraform.sh
+        working-directory: ./
         shell: bash
-        run: |
-          cat << EOF > provider.tf
-          provider "azurerm" {
-            features {}
-          }
-          EOF
+
       - name: Terraform Init
         run: terraform init
-
-      - name: Terraform format
-        run: terraform fmt -check
+        working-directory: example
 
       - name: Terraform validate
         run: terraform validate
+        working-directory: example
+
+      - name: Terraform format
+        run: terraform fmt -check -recursive

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,25 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.product}-${var.env}-rg"
+  location = var.location
+
+  tags = module.tags.common_tags
+}
+
+module "this" {
+  source = "../"
+
+  name           = "plum-subscription"
+  namespace_name = "plum-servicebus-sandbox"
+  topic_name     = "plum-to-cft"
+
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+# projects run on Jenkins do not need this module should and should just pass through var.common_tags instead
+module "tags" {
+  source       = "git::https://github.com/hmcts/terraform-module-common-tags.git?ref=master"
+  environment  = var.env
+  product      = var.product
+  builtFrom    = var.builtFrom
+  expiresAfter = "2023-01-30"
+}

--- a/example/provider.tf
+++ b/example/provider.tf
@@ -1,0 +1,3 @@
+provider "azurerm" {
+  features {}
+}

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,15 @@
+variable "env" {
+  default = "sandbox"
+}
+
+variable "product" {
+  default = "platops"
+}
+
+variable "builtFrom" {
+  default = "local"
+}
+
+variable "location" {
+  default = "UK South"
+}

--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,11 @@ resource "azurerm_servicebus_subscription" "servicebus_subscription" {
   forward_to                        = var.forward_to
   forward_dead_lettered_messages_to = var.forward_dead_lettered_messages_to
 
-  requires_session                     = var.requires_session
-  dead_lettering_on_message_expiration = true
-  enable_batched_operations            = false
-  default_message_ttl                  = "P10675199DT2H48M5.4775807S"
-  auto_delete_on_idle                  = "P10675199DT2H48M5.4775807S"
+  requires_session                      = var.requires_session
+  dead_lettering_on_message_expiration  = true
+  batched_operations_enabled            = false
+  default_message_ttl                   = "P10675199DT2H48M5.4775807S"
+  auto_delete_on_idle                   = "P10675199DT2H48M5.4775807S"
 }
 
 resource "azurerm_servicebus_subscription_rule" "sql_filter_rule" {

--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,11 @@ resource "azurerm_servicebus_subscription" "servicebus_subscription" {
   forward_to                        = var.forward_to
   forward_dead_lettered_messages_to = var.forward_dead_lettered_messages_to
 
-  requires_session                      = var.requires_session
-  dead_lettering_on_message_expiration  = true
-  batched_operations_enabled            = false
-  default_message_ttl                   = "P10675199DT2H48M5.4775807S"
-  auto_delete_on_idle                   = "P10675199DT2H48M5.4775807S"
+  requires_session                     = var.requires_session
+  dead_lettering_on_message_expiration = true
+  batched_operations_enabled           = false
+  default_message_ttl                  = "P10675199DT2H48M5.4775807S"
+  auto_delete_on_idle                  = "P10675199DT2H48M5.4775807S"
 }
 
 resource "azurerm_servicebus_subscription_rule" "sql_filter_rule" {


### PR DESCRIPTION
Relating to DTSPO-18682 (https://tools.hmcts.net/jira/browse/DTSPO-18682)

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azurerm_servicebus_subscription

Provider Release notes https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.112.0

Provider change: https://github.com/hashicorp/terraform-provider-azurerm/pull/26479

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
