### PR TITLE
Add flag to allow teams to set the subscription status

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "azurerm_servicebus_subscription" "servicebus_subscription" {
   enable_batched_operations            = false
   default_message_ttl                  = "P10675199DT2H48M5.4775807S"
   auto_delete_on_idle                  = "P10675199DT2H48M5.4775807S"
+  status                               = var.status
 }
 
 resource "azurerm_servicebus_subscription_rule" "sql_filter_rule" {

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 3.0.0, < 4.0.0"
     }
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0, < 4.0.0"
+      version = ">= 3.0.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,14 @@ variable "correlation_filters" {
     error_message = "At least one of \"content_type\", \"correlation_id\", \"label\", \"message_id\", \"reply_to\", \"reply_to_session_id\", \"session_id\", \"to\" or \"properties\" must be set on every correlation_filter block."
   }
 }
+
+variable "status" {
+  type        = string
+  description = "Status of the Service Bus subscription"
+  default     = "Active"
+  validation {
+    condition     = can(regex("^(Active|Disabled|ReceiveDisabled)$", var.status))
+    error_message = "Status must be either 'Active', 'Disabled' or 'ReceiveDisabled'"
+  }
+
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25025

### Change description
- Brought up during above ticket that a team wanted the ability to disable their servicebus subscription via IaC
- Adding functionality to module to allow this
- Defaulting to `Active` so won't cause any disruption
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
