### PR TITLE
Dtspo 25025 add status flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "azurerm_servicebus_subscription" "servicebus_subscription" {
   batched_operations_enabled           = false
   default_message_ttl                  = "P10675199DT2H48M5.4775807S"
   auto_delete_on_idle                  = "P10675199DT2H48M5.4775807S"
+  status                               = var.status
 }
 
 resource "azurerm_servicebus_subscription_rule" "sql_filter_rule" {

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,14 @@ variable "correlation_filters" {
     error_message = "At least one of \"content_type\", \"correlation_id\", \"label\", \"message_id\", \"reply_to\", \"reply_to_session_id\", \"session_id\", \"to\" or \"properties\" must be set on every correlation_filter block."
   }
 }
+
+variable "status" {
+  type        = string
+  description = "The status of the Service Bus Subscription"
+  default     = "Active"
+  validation {
+    condition     = can(regex("Active|Disabled|ReceiveDisabled", var.status))
+    error_message = "status must be either Active, Disabled or ReceiveDisabled"
+  }
+
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25025

### Change description
- Brought up during above ticket that a team wanted the ability to disable their servicebus subscription via IaC
- Adding functionality to module to allow this
- Defaulting to `Active` so won't cause any disruption

### Testing done
- Tested on `civil-service` repo with and without status flag defined

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
