### PR TITLE
DTSPO-26253 - Switch to namespace_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "azurerm_servicebus_topic" "this" {
   name                = var.topic_name
   resource_group_name = var.resource_group_name
-  namespace_name      = var.namespace_name
+  namespace_id        = var.namespace_id
 }
 
 resource "azurerm_servicebus_subscription" "servicebus_subscription" {

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,12 @@
 data "azurerm_servicebus_namespace" "this" {
+  count               = var.topic_name == null ? 0 : 1
   name                = var.namespace_name
   resource_group_name = var.resource_group_name
 }
 
 
 data "azurerm_servicebus_topic" "this" {
+  count               = var.topic_name == null ? 0 : 1
   name                = var.topic_name
   resource_group_name = var.resource_group_name
   namespace_id        = data.azurerm_servicebus_namespace.this.id
@@ -12,7 +14,7 @@ data "azurerm_servicebus_topic" "this" {
 
 resource "azurerm_servicebus_subscription" "servicebus_subscription" {
   name     = var.name
-  topic_id = data.azurerm_servicebus_topic.this.id
+  topic_id = var.topic_name == null ? data.azurerm_servicebus_topic.this.id : var.topic_id
 
   lock_duration                     = var.lock_duration
   max_delivery_count                = var.max_delivery_count

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,13 @@
+data "azurerm_servicebus_namespace" "this" {
+  name                = var.namespace_name
+  resource_group_name = var.resource_group_name
+}
+
+
 data "azurerm_servicebus_topic" "this" {
   name                = var.topic_name
   resource_group_name = var.resource_group_name
-  namespace_id        = var.namespace_id
+  namespace_id        = data.azurerm_servicebus_namespace.this.id
 }
 
 resource "azurerm_servicebus_subscription" "servicebus_subscription" {

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_servicebus_subscription" "servicebus_subscription" {
 
   requires_session                     = var.requires_session
   dead_lettering_on_message_expiration = true
-  enable_batched_operations            = false
+  batched_operations_enabled           = false
   default_message_ttl                  = "P10675199DT2H48M5.4775807S"
   auto_delete_on_idle                  = "P10675199DT2H48M5.4775807S"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,10 @@
 data "azurerm_servicebus_namespace" "this" {
-  count               = var.topic_name == null ? 0 : 1
   name                = var.namespace_name
   resource_group_name = var.resource_group_name
 }
 
 
 data "azurerm_servicebus_topic" "this" {
-  count               = var.topic_name == null ? 0 : 1
   name                = var.topic_name
   resource_group_name = var.resource_group_name
   namespace_id        = data.azurerm_servicebus_namespace.this.id
@@ -14,7 +12,7 @@ data "azurerm_servicebus_topic" "this" {
 
 resource "azurerm_servicebus_subscription" "servicebus_subscription" {
   name     = var.name
-  topic_id = var.topic_name == null ? data.azurerm_servicebus_topic.this.id : var.topic_id
+  topic_id = var.topic_id == null ? data.azurerm_servicebus_topic.this.id : var.topic_id
 
   lock_duration                     = var.lock_duration
   max_delivery_count                = var.max_delivery_count

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "namespace_id" {
   description = "Azure Service Bus namespace id"
 }
 
+variable "namespace_name" {
+  type        = string
+  description = "Azure Service Bus namespace name"
+}
+
 variable "topic_name" {
   type        = string
   description = "Azure Service Bus topic name"

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "namespace_id" {
 variable "namespace_name" {
   type        = string
   description = "Azure Service Bus namespace name"
+  default     = null
 }
 
 variable "topic_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ variable "name" {
 variable "namespace_id" {
   type        = string
   description = "Azure Service Bus namespace id"
+  default     = null
 }
 
 variable "namespace_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "namespace_name" {
 }
 
 variable "topic_name" {
-  type        = optional(string)
+  type        = string
   description = "Azure Service Bus topic name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "namespace_name" {
 }
 
 variable "topic_name" {
-  type        = string
+  type        = optional(string)
   description = "Azure Service Bus topic name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "topic_name" {
   description = "Azure Service Bus topic name"
 }
 
+variable "topic_id" {
+  type        = string
+  description = "Azure Service Bus topic ID. If provided, it will be used instead of topic_name"
+  default     = null
+}
+
 variable "resource_group_name" {
   type        = string
   description = "Resource group in which the Service Bus subscription should exist"


### PR DESCRIPTION
### Jira link

See [DTSPO-26253](https://tools.hmcts.net/jira/browse/DTSPO-26253)

### Change description

Namespace name has been removed as an attribute and replaced with namespace_id.
Adding support for this change and also adding logic to allow teams to pass topic_id instead of topic_name to prevent unnecessary changes being made in pipelines.

### Testing done

rd-shared-infrastructure pipeline has been ran. See https://github.com/hmcts/rd-shared-infrastructure/pull/282

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
